### PR TITLE
Added function to recognize if a comment is made by a mentor or not

### DIFF
--- a/messages.py
+++ b/messages.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 MESSAGE = {
     'first_timer_message': 'Hello!\nWelcome to the Systers Open Source community!\nHow to get started:'+\

--- a/slack_functions.py
+++ b/slack_functions.py
@@ -1,16 +1,19 @@
+# -*- coding: utf-8 -*-
+
 import requests
 from flask import request, json, jsonify
-from auth_credentials import  BOT_ACCESS_TOKEN
-from request_urls import dm_channel_open_url, dm_chat_post_message_url
+from auth_credentials import  BOT_ACCESS_TOKEN, maintainer_usergroup_id, legacy_token
+from request_urls import dm_channel_open_url, dm_chat_post_message_url, get_maintainer_list
 from messages import MESSAGE
 
+headers = {'Content-type': 'application/json', 'Authorization': 'Bearer {}'.format(BOT_ACCESS_TOKEN)}
+headers_legacy_urlencoded = {'Content-type': 'application/x-www-form-urlencoded', 'Authorization': 'Bearer {}'.format(legacy_token)}
 
 def dm_new_users(data):
     #Get user id of the user who joined
     uid = data.get('event',{}).get('user',None)
     if uid != None:
         body = {'user': uid}
-        headers = {'Content-type': 'application/json', 'Authorization': 'Bearer {}'.format(BOT_ACCESS_TOKEN)}
         #Open a DM channel to the user. Request goes to im.open
         r = requests.post(dm_channel_open_url, data=json.dumps(body), headers=headers)
         response = r.json()
@@ -24,3 +27,20 @@ def dm_new_users(data):
                 print("Response: %s" % json.dumps(r.json()))
                 return {'message':'Success','status': 200}
     return {'message':'Data format wrong', 'status':400}
+
+
+def is_maintainer_comment(commenter_id):
+    #Using the id of usergroup maintainers
+    body = {'usergroup': maintainer_usergroup_id, 'include_disabled': True}
+    #Get list of maintainers. For more info :  usergroups.users.list in Slack API
+    r = requests.post(get_maintainer_list, data= body, headers=headers_legacy_urlencoded)
+    response = r.json()
+    if response.get('ok',False):
+        #Extract the maintainers
+        maintainers = response.get('users',[])
+        if commenter_id in maintainers:
+            return {'status': 200, 'is_maintainer': True}
+        else:
+            return {'status': 200, 'is_maintainer': True}
+    else:
+        return {'status': 400, 'message': 'Wrong parameters'}


### PR DESCRIPTION
# Description
Included a function that will check if a commentors id is in a list of maintainers on Slack, to identify if a comment is being made by a maintainer.

Fixes #9 

# Type of Change:
- Code
- New feature (a non-breaking change which adds functionality pre-approved by mentors)

# How Has This Been Tested?
Once a Maintainers ID has been used and once the ID of a different user. Following were the results.

![maintainer_list](https://user-images.githubusercontent.com/24635701/40319065-71f2e6d8-5d44-11e8-8750-900897f90e22.png)


# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
