### PR TITLE
Added feature to claim issues from github

### DIFF
--- a/github_functions.py
+++ b/github_functions.py
@@ -1,7 +1,8 @@
 import requests
 from flask import request, json
-from request_urls import add_label_url, send_team_invite, assign_issue_url
+from request_urls import add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url
 from auth_credentials import USERNAME,PASSWORD, newcomers_team_id
+from messages import MESSAGE
 
 #request headers
 headers = {'Accept': 'application/vnd.github.symmetra-preview+json', 'Content-Type': 'application/x-www-form-urlencoded'}
@@ -87,3 +88,34 @@ def issue_assign(issue_number, repo_name, assignee, repo_owner):
     request_url = assign_issue_url % (repo_owner, repo_name, issue_number)
     response = session.patch(request_url, data=label, headers=headers)
     return response.status_code
+
+
+def check_assignee_validity(repo_name, assignee, repo_owner):
+    session = requests.Session()
+    session.auth = (USERNAME, PASSWORD)
+    request_url = check_assignee_url % (repo_owner, repo_name, assignee)
+    response = session.get(request_url)
+    return response.status_code
+
+
+def github_comment(message,repo_owner, repo_name,issue_number):
+    body = '{"body":"%s"}' % message
+    session = requests.Session()
+    session.auth = (USERNAME, PASSWORD)
+    headers = {'Accept': 'application/vnd.github.machine-man-preview',
+               'Content-Type': 'application/x-www-form-urlencoded'}
+    request_url = github_comment_url % (repo_owner, repo_name, issue_number)
+    response = session.post(request_url, data=body, headers=headers)
+    return response.status_code
+
+
+def issue_claim_github(assignee, issue_number, repo_name, repo_owner):
+    status = check_assignee_validity(repo_name, assignee, repo_owner)
+    #Check if the assignee is valid. For more info : https://developer.github.com/v3/issues/assignees/#check-assignee
+    if status == 404:
+        #If member cant be assigned
+        github_comment(MESSAGE.get('not_an_org_member', ''),
+                       repo_owner, repo_name, issue_number)
+    if status == 204:
+        #If member can be assigned an issue.
+        issue_assign(issue_number, repo_name, assignee, repo_owner)

--- a/main_server.py
+++ b/main_server.py
@@ -1,11 +1,12 @@
 from flask import Flask, jsonify
 from flask import request, json, Response
-from github_functions import label_opened_issue, issue_comment_approve_github, github_pull_request_label, issue_assign
+from github_functions import label_opened_issue, issue_comment_approve_github, github_pull_request_label, issue_assign, github_comment, issue_claim_github
 from stemming.porter2 import stem
 from nltk.tokenize import word_tokenize
 from auth_credentials import announcement_channel_id, BOT_ACCESS_TOKEN
 from slack_functions import dm_new_users, check_newcomer_requirements, approve_issue_label_slack, assign_issue_slack
 from nltk.stem import WordNetLemmatizer
+from messages import MESSAGE
 
 app = Flask(__name__)
 
@@ -19,7 +20,6 @@ def home():
 def github_hook_receiver_function():
     if request.headers['Content-Type'] == 'application/json':
         data = request.json
-        print(json.dumps(data))
         action = data.get('action', None)
         if action!=None:
             if action == 'opened' and data.get('pull_request', '') == '':
@@ -38,6 +38,11 @@ def github_hook_receiver_function():
                 #If comment is to assign issue
                 elif comment_body.lower().startswith('@sys-bot assign') and len(tokens) == 3:
                     issue_assign(issue_number, repo_name, tokens[2], repo_owner)
+                elif comment_body.lower().startswith('@sys-bot claim') and len(tokens) == 2:
+                    assignee = data.get('comment', {}).get('user', {}).get('login', '')
+                    issue_claim_github(assignee, issue_number, repo_name, repo_owner)
+                elif comment_body.lower().startswith('@sys-bot claim') and len(tokens) != 2:
+                    github_comment(MESSAGE.get('wrong_format_github', ''), repo_owner, repo_name, issue_number)
             elif action == 'opened' and data.get('pull_request', '') != '':
                 #If a new PR has been sent
                 pr_number = data.get('number', '')

--- a/messages.py
+++ b/messages.py
@@ -18,5 +18,7 @@ MESSAGE = {
     'correct_approve_format': 'The correct format is /sysbot_approve_issue <repo> <issue_no>',
     'error_slash_command': 'The slash command got a 500 error. Please check and try again.',
     'not_a_maintainer': 'You are not a maintainer. Please contact <@U0BKKUBQU|may> to get added.',
-    'correct_assign_format': 'The correct format is /sysbot_assign_issue <repo_name> <issue_no> <assignee_github_username>'
+    'correct_assign_format': 'The correct format is /sysbot_assign_issue <repo_name> <issue_no> <assignee_github_username>',
+    'not_an_org_member': 'You can\'t be assigned as you are not a member of the org. Join slack for more info',
+    'wrong_format_github': 'Wrong format of command'
 }


### PR DESCRIPTION
# Description
Added feature to claim issues via Github comment @sys-bot claim. This will only work if a person is a member of the organization. 
For more details read https://developer.github.com/v3/issues/assignees/#check-assignee, https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue

Fixes #42 

# Type of Change:

- Code
- New feature (a non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
![before_command](https://user-images.githubusercontent.com/24635701/40781530-cfb50654-64f9-11e8-82f4-718a5d266ca5.png)
![after_command](https://user-images.githubusercontent.com/24635701/40781532-d157d306-64f9-11e8-895d-d34cca68b93c.png)

# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
