### PR TITLE
Added feature to stop multiple claims of an issue

### DIFF
--- a/github_functions.py
+++ b/github_functions.py
@@ -1,6 +1,6 @@
 import requests
 from flask import request, json
-from request_urls import add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url
+from request_urls import add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url, get_issue_url
 from auth_credentials import USERNAME,PASSWORD, newcomers_team_id
 from messages import MESSAGE
 
@@ -119,3 +119,18 @@ def issue_claim_github(assignee, issue_number, repo_name, repo_owner):
     if status == 204:
         #If member can be assigned an issue.
         issue_assign(issue_number, repo_name, assignee, repo_owner)
+
+
+def check_multiple_issue_claim(repo_owner, repo_name, issue_number):
+    session = requests.Session()
+    session.auth = (USERNAME, PASSWORD)
+    request_url = get_issue_url % (repo_owner, repo_name, issue_number)
+    response = session.get(request_url).json()
+    #Get the list of assignees
+    assignee_list = response.get('assignees', [])
+    if not assignee_list:
+        #If issue hasn't been claimed send False
+        return False
+    else:
+        #If issue has been claimed send True
+        return True

--- a/messages.py
+++ b/messages.py
@@ -20,7 +20,8 @@ MESSAGE = {
     'not_a_maintainer': 'You are not a maintainer. Please contact <@U0BKKUBQU|may> to get added.',
     'correct_assign_format': 'The correct format is /sysbot_assign_issue <repo_name> <issue_no> <assignee_github_username>',
     'not_an_org_member': 'You can\'t be assigned as you are not a member of the org. Join slack for more info.',
-    'wrong_format_github': 'Wrong format of command.'
+    'wrong_format_github': 'Wrong format of command.',
     'correct_claim_format': 'The correct format is /sysbot_claim <repo_name> <issue_no> <your_github_username>',
-    'not_a_member': 'You are not a member of the org yet. Please use /sysbot_invite to get invited to newcomers team.'
+    'not_a_member': 'You are not a member of the org yet. Please use /sysbot_invite to get invited to newcomers team.',
+    'already_claimed': 'This issue has already been assigned or claimed. Please try another issue.'
 }


### PR DESCRIPTION
# Description
Added feature to check if an already assigned issue is being claimed or being assigned. Send messages or comment accordingly. 

Fixes #46 

# Type of Change:
- Code
- New feature (a non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
![claimed](https://user-images.githubusercontent.com/24635701/40903118-f8f81ae0-67f3-11e8-9723-2db0376a72f8.png)
![claim_slack](https://user-images.githubusercontent.com/24635701/40903126-fb2bbec0-67f3-11e8-8a9e-bfc93411ad89.png)

# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
