### PR TITLE
Added feature for checking coveralls comment

### DIFF
--- a/main_server.py
+++ b/main_server.py
@@ -32,7 +32,13 @@ def github_hook_receiver_function():
                 repo_owner = data.get('repository', {}).get('owner', {}).get('login', '')
                 comment_body = data.get('comment', {}).get('body', '')
                 tokens = comment_body.split(' ')
+                commenter = data.get('comment', {}).get('user', {}).get('login', '')
                 is_issue_claimed_or_assigned = check_multiple_issue_claim(repo_owner, repo_name, issue_number)
+
+                #Check if the comment by coveralls
+                if commenter == 'coveralls' and 'Coverage decreased' in comment_body:
+                    github_comment(MESSAGE.get('add_tests', ''), repo_owner, repo_name, issue_number)
+
                 #If comment is for approving issue
                 if comment_body.lower() == '@sys-bot approve':
                     issue_comment_approve_github(issue_number, repo_name, repo_owner)
@@ -51,7 +57,7 @@ def github_hook_receiver_function():
                 #If comment is to claim issue
                 if comment_body.lower().startswith('@sys-bot claim'):
                     if len(tokens) == 2 and not is_issue_claimed_or_assigned:
-                        assignee = data.get('comment', {}).get('user', {}).get('login', '')
+                        assignee = commenter
                         issue_claim_github(assignee, issue_number, repo_name, repo_owner)
                     elif len(tokens) != 2 and not is_issue_claimed_or_assigned:
                         github_comment(MESSAGE.get('wrong_format_github', ''), repo_owner, repo_name, issue_number)

--- a/messages.py
+++ b/messages.py
@@ -23,5 +23,6 @@ MESSAGE = {
     'wrong_format_github': 'Wrong format of command.',
     'correct_claim_format': 'The correct format is /sysbot_claim <repo_name> <issue_no> <your_github_username>',
     'not_a_member': 'You are not a member of the org yet. Please use /sysbot_invite to get invited to newcomers team.',
-    'already_claimed': 'This issue has already been assigned or claimed. Please try another issue.'
+    'already_claimed': 'This issue has already been assigned or claimed. Please try another issue.',
+    'add_tests': 'Please add tests as the coverage has decreased.'
 }


### PR DESCRIPTION
# Description
Treats the coveralls comment on PRs as any other comment and checks if ‘Coverage decreased’ is present in the comment body and comments accordingly for writing tests.

Fixes #47 

# Type of Change:

- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)


# Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] Any dependent changes have been merged 
- [ ] My changes generate no new warnings 
