### PR TITLE
Added design doc file for template matching of issues

### DIFF
--- a/docs/template_matching_design.md
+++ b/docs/template_matching_design.md
@@ -1,0 +1,38 @@
+###Sysbot
+By - Sammy1997  
+Mentors: Ramit Sawhney, Akshita Aggarwal  
+Admin: Prachi Manchanda  
+
+###Design for Template matching
+**June 02, 2018**  
+
+Following are the links to a sample issue which follows the template
+and the body of the issue as sent to the
+server by the web-hook:  
+
+[Issue](https://github.com/systers/sysbot-test/issues/48)  
+[Response](https://dpaste.de/Pb7x)  
+
+So basically the task is to search in the body of the issue,
+for the presence of these headers :  
+
+1. **Description**
+2. **Acceptance Criteria** - followed by “Update” or “Update [Required]”
+3. **Definition of Done**
+4. **Estimation**  
+
+We are not considering **Mocks and Enhancements** as they are optional
+and may or may not be present.  
+
+When we use these [lines of code](https://dpaste.de/ZGAj) on this [Response](https://dpaste.de/Pb7x) , we get the following [tokens](https://dpaste.de/jRDh).  
+
+From this final curated list of tokens,
+we need to iterate through the tokens and search for the above given words in the tokens in each run.  
+
+If all are present, along with some text in the next token then we can say that this is a valid template.  
+
+I would like to discuss the course of action that is to be taken if invalid issues are found.  
+
+As per discussion with the community, the bot would add a ***label of “Template Mismatch” to them***,
+so that the mentors/admins/maintainers could see all the issues by searching by this label,
+and then they will be ***closed manually***. Also, ***any issue labelled "Template Mismatch"  can't be approved, assigned or claimed***.


### PR DESCRIPTION
# Description
Added design doc file for checking the issue bodies and matching them to see if they follow the standards.

Fixes #48 

# Type of Change:
- Documentation
- This change requires a documentation update (software upgrade on readme file)


# How Has This Been Tested?
![view_of_design_readme](https://user-images.githubusercontent.com/24635701/41031635-c149c272-699e-11e8-83f9-e4ce5558c79c.png)

# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings 
