### PR TITLE
Added feature for opening issues via Slack. Markdown not supported

### DIFF
--- a/github_functions.py
+++ b/github_functions.py
@@ -1,6 +1,6 @@
 import requests
 from flask import request, json
-from request_urls import add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url, get_issue_url
+from request_urls import (add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url, get_issue_url, open_issue_url)
 from auth_credentials import USERNAME,PASSWORD, newcomers_team_id
 from messages import MESSAGE
 
@@ -134,3 +134,14 @@ def check_multiple_issue_claim(repo_owner, repo_name, issue_number):
     else:
         #If issue has been claimed send True
         return True
+
+
+def open_issue_github(repo_owner, repo_name, issue_title, issue_body, author):
+    session = requests.Session()
+    session.auth = (USERNAME, PASSWORD)
+    request_url = open_issue_url % (repo_owner, repo_name)
+    headers = {'Accept': 'application/vnd.github.symmetra-preview+json', 'Content-Type': 'application/json'}
+    #Raw issue body.
+    issue_request_body = '{"title": "%s", "body": "%s.<br>Authored by %s via Slack", "assignees": [], "labels": []}' % (issue_title, issue_body, author)
+    response = session.post(request_url, data=issue_request_body, headers=headers)
+    return response.status_code

--- a/main_server.py
+++ b/main_server.py
@@ -4,7 +4,7 @@ from github_functions import label_opened_issue, issue_comment_approve_github, g
 from stemming.porter2 import stem
 from nltk.tokenize import word_tokenize
 from auth_credentials import announcement_channel_id, BOT_ACCESS_TOKEN
-from slack_functions import dm_new_users, check_newcomer_requirements, approve_issue_label_slack, assign_issue_slack, claim_issue_slack
+from slack_functions import dm_new_users, check_newcomer_requirements, approve_issue_label_slack, assign_issue_slack, claim_issue_slack, open_issue_slack
 from nltk.stem import WordNetLemmatizer
 from messages import MESSAGE
 
@@ -129,6 +129,14 @@ def slack_claim_receiver():
     if request.headers['Content-Type'] == 'application/x-www-form-urlencoded':
         claimers_info = request.form
         claim_issue_slack(claimers_info)
+        return Response(status=200)
+
+
+@app.route('/open_issue', methods=['POST'])
+def open_issue_receiver():
+    if request.headers['Content-Type'] == 'application/x-www-form-urlencoded':
+        openers_info = request.form
+        open_issue_slack(openers_info)
         return Response(status=200)
 
 

--- a/messages.py
+++ b/messages.py
@@ -25,5 +25,8 @@ MESSAGE = {
     'not_a_member': 'You are not a member of the org yet. Please use /sysbot_invite to get invited to newcomers team.',
     'already_claimed': 'This issue has already been assigned or claimed. Please try another issue.',
     'add_tests': 'Please add tests as the coverage has decreased.',
-    'invite_sent': 'Invitation has been sent.'
+    'invite_sent': 'Invitation has been sent.',
+    'wrong_params_issue_command': 'Insufficient or wrong parameters for issue command.',
+    'success_issue': 'Successfully opened issue.',
+    'error_issue': 'Some error occurred while opening issue. Please try again.'
 }


### PR DESCRIPTION
# Description  
Feature to open issues from Slack. Markdown type body not supported yet. Issues can be opened with slash command /sysbot_open_issue <repo-name> <Author username> *Title of issue( in stars)* <body>

Fixes #40 

# Type of Change:
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
![test issue](https://user-images.githubusercontent.com/24635701/41035824-87edb558-69ab-11e8-8306-8047b0d7d46e.png)

# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
