### PR TITLE
Added versatility in recognising issue approval comments

### DIFF
--- a/messages.py
+++ b/messages.py
@@ -25,5 +25,6 @@ MESSAGE = {
     'not_a_member': 'You are not a member of the org yet. Please use /sysbot_invite to get invited to newcomers team.',
     'already_claimed': 'This issue has already been assigned or claimed. Please try another issue.',
     'add_tests': 'Please add tests as the coverage has decreased.',
-    'invite_sent': 'Invitation has been sent.'
+    'invite_sent': 'Invitation has been sent.',
+    'no_write_access': 'You do not have write access in this repo.'
 }


### PR DESCRIPTION
# Description
Added stemming so that approval comments from maintainers can be recognized more efficiently.

Fixes #57 

# Type of Change:
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
![issue_approval_versatile](https://user-images.githubusercontent.com/24635701/41039781-1ef81de2-69b8-11e8-98f4-fb5fc7bba03f.png)
![isse_versatile_2](https://user-images.githubusercontent.com/24635701/41039783-20bd33ce-69b8-11e8-912b-b25055bab4ca.png)


# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
