### PR TITLE
Added feature for comments to be only visible to the commentor

### DIFF
--- a/slack_functions.py
+++ b/slack_functions.py
@@ -3,7 +3,7 @@
 import requests
 from flask import request, json, jsonify
 from auth_credentials import  BOT_ACCESS_TOKEN, maintainer_usergroup_id, legacy_token, org_repo_owner
-from request_urls import dm_channel_open_url, dm_chat_post_message_url, get_maintainer_list, get_user_profile_info_url
+from request_urls import dm_channel_open_url, dm_chat_post_message_url, get_maintainer_list, get_user_profile_info_url, chat_post_ephimeral_message_url
 from messages import MESSAGE
 from github_functions import send_github_invite, issue_comment_approve_github, issue_assign, check_assignee_validity, check_multiple_issue_claim
 
@@ -50,6 +50,7 @@ def is_maintainer_comment(commenter_id):
 def approve_issue_label_slack(data):
     result = is_maintainer_comment(data.get('user_id', ''))
     channel_id = data.get('channel_id','')
+    uid = data.get('user_id','')
     if result.get('is_maintainer', False):
         params = data.get('text','')
         if params != '' and len(params.split(' ')) == 2:
@@ -57,19 +58,19 @@ def approve_issue_label_slack(data):
             status = response.get('status', 500)
             if status == 404:
                 #Information given is wrong
-                send_message_to_channels(channel_id, MESSAGE.get('wrong_info',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('wrong_info',''))
             elif status == 200:
                 #Successful labeling
-                send_message_to_channels(channel_id, MESSAGE.get('success',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('success',''))
             elif status == 500:
                 #Some internal error occured
-                send_message_to_channels(channel_id, MESSAGE.get('error_slash_command',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('error_slash_command',''))
         else:
             #Wrong format of command was used
-            send_message_to_channels(channel_id, MESSAGE.get('correct_approve_format',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('correct_approve_format',''))
     else:
         #The commentor is not a maintainer
-        send_message_to_channels(channel_id, MESSAGE.get('not_a_maintainer',''))
+        send_message_ephimeral(channel_id, uid, MESSAGE.get('not_a_maintainer',''))
 
 
 def check_newcomer_requirements(uid, channel_id):
@@ -89,14 +90,15 @@ def check_newcomer_requirements(uid, channel_id):
                 break
         if github_profile_present and profile.get('first_name', "") != "" and profile.get('last_name',"")!="" and profile.get('title',"")!="" and profile.get('image_original',"")!="" and not profile.get('phone',"").isdigit():
             send_github_invite(github_id)
-            send_message_to_channels(channel_id, MESSAGE.get('invite_sent',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('invite_sent',''))
         else:
-            send_message_to_channels(channel_id, MESSAGE.get('newcomer_requirement_incomplete',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('newcomer_requirement_incomplete',''))
 
 
 def assign_issue_slack(data):
     result = is_maintainer_comment(data.get('user_id', ''))
     channel_id = data.get('channel_id','')
+    uid = data.get('user_id','')
     if result.get('is_maintainer', False):
         params = data.get('text','')
         tokens = params.split(' ')
@@ -105,37 +107,38 @@ def assign_issue_slack(data):
             is_issue_claimed_or_assigned = check_multiple_issue_claim(org_repo_owner, tokens[0], tokens[1])
             #If issue has been claimed, send message to the channel
             if is_issue_claimed_or_assigned:
-                send_message_to_channels(channel_id, MESSAGE.get('already_claimed',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('already_claimed',''))
                 return
             #If issue is available, then check for assign status
             status = issue_assign(tokens[1], tokens[0], tokens[2], org_repo_owner)
             if status == 404:
                 #Information given is wrong
-                send_message_to_channels(channel_id, MESSAGE.get('wrong_info',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('wrong_info',''))
             elif status == 200:
                 #Successful assignment
-                send_message_to_channels(channel_id, MESSAGE.get('success',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('success',''))
             elif status == 500:
                 #Some internal error occured
-                send_message_to_channels(channel_id, MESSAGE.get('error_slash_command',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('error_slash_command',''))
         else:
             #Wrong format of command was used
-            send_message_to_channels(channel_id, MESSAGE.get('correct_assign_format',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('correct_assign_format',''))
     else:
         #The commentor is not a maintainer
-        send_message_to_channels(channel_id, MESSAGE.get('not_a_maintainer',''))
+        send_message_ephimeral(channel_id, uid, MESSAGE.get('not_a_maintainer',''))
 
 
 def claim_issue_slack(data):
     params = data.get('text','')
     tokens = params.split(' ')
     channel_id = data.get('channel_id','')
+    uid = data.get('user_id','')
     if params != '' and len(tokens) == 3:
         #The tokens are issue number, repo name, and claimant's username
         is_issue_claimed_or_assigned = check_multiple_issue_claim(org_repo_owner, tokens[0], tokens[1])
         #If issue has been claimed, send message to the channel
         if is_issue_claimed_or_assigned:
-            send_message_to_channels(channel_id, MESSAGE.get('already_claimed',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('already_claimed',''))
             return
         #If issue is available, then check for assign status
         status = issue_assign(tokens[1], tokens[0], tokens[2], org_repo_owner)
@@ -145,22 +148,27 @@ def claim_issue_slack(data):
             assignee_status = check_assignee_validity(tokens[0], tokens[2], org_repo_owner)
             if assignee_status == 404:
                 #Can't be assigned as not a member
-                send_message_to_channels(channel_id, MESSAGE.get('not_a_member',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('not_a_member',''))
                 return
             else:
                 #Information given is wrong
-                send_message_to_channels(channel_id, MESSAGE.get('wrong_info',''))
+                send_message_ephimeral(channel_id, uid, MESSAGE.get('wrong_info',''))
         elif status == 200:
             #Successful claim
-            send_message_to_channels(channel_id, MESSAGE.get('success',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('success',''))
         elif status == 500:
             #Some internal error occured
-            send_message_to_channels(channel_id, MESSAGE.get('error_slash_command',''))
+            send_message_ephimeral(channel_id, uid, MESSAGE.get('error_slash_command',''))
     else:
         #Wrong format of command was used
-        send_message_to_channels(channel_id, MESSAGE.get('correct_claim_format',''))
+        send_message_ephimeral(channel_id, uid, MESSAGE.get('correct_claim_format',''))
 
 
 def send_message_to_channels(channel_id, message):
     body = {'username': 'Sysbot', 'as_user': True, 'text': message, 'channel': channel_id}
     requests.post(dm_chat_post_message_url, data=json.dumps(body), headers=headers)
+
+
+def send_message_ephimeral(channel_id, uid, message):
+    body = {'username': 'Sysbot', 'as_user': True, 'text': message, 'channel': channel_id, 'user': uid}
+    requests.post(chat_post_ephimeral_message_url, data=json.dumps(body), headers=headers)


### PR DESCRIPTION
# Description
The comments made by Sysbot as a response to Slash commands will only be visible only to the user, n not publicly on the channel.

Fixes #59 

# Type of Change:
- Code
- New feature (a non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
![ephimeral](https://user-images.githubusercontent.com/24635701/41152880-a3cc1fca-6b32-11e8-8ea9-46785ddcb452.png)


# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
