### PR TITLE
Added patch for claim command to accept github username from Slack profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ newcomer member level is completed as mentioned [here](http://systers.io/member-
 However this command can only be used by members of @maintainers team on Slack. E.g. of usage - /sysbot_approve_issue sysbot 23 .
 4. A slash command /sysbot_assign_issue <repo_name> <issue_number> <assignee_github_username> can be used to assign any issue from Github directly via Slack.
 However this command can only be used by members of @maintainers team on Slack. E.g. of usage - /sysbot_assign_issue sysbot 23 sammy1997.
-5. A slash command /sysbot_claim <repo_name> <issue_number> <assignee_github_username> can be used to claim any issue from Github directly via Slack.
+5. A slash command /sysbot_claim <repo_name> <issue_number> <assignee_github_username> or /sysbot_claim <repo_name> <issue_number> ( the latter option will work if your github URL is provided on Slack) can be used to claim any issue from Github directly via Slack.
 E.g. of usage - /sysbot_claim sysbot 23.
 [NOTE: To claim or assign an issue, it must first be approved]
 6. A slash command /sysbot_open_issue <repo_name> <author_username> *Title of issue(in between star symbols)* Issue Body  

--- a/messages.py
+++ b/messages.py
@@ -29,5 +29,6 @@ MESSAGE = {
     'wrong_params_issue_command': 'Insufficient or wrong parameters for issue command.',
     'success_issue': 'Successfully opened issue.',
     'error_issue': 'Some error occurred while opening issue. Please try again.',
-    'author_cannot_approve': 'The author of the issue cannot approve the issue.'
+    'author_cannot_approve': 'The author of the issue cannot approve the issue.',
+    'error_claim_alternate': 'To use this format of the command, please complete your Slack profile with your Github account link.'
 }


### PR DESCRIPTION
# Description
Added the feature to accept GitHub username directly Slack profile.

Fixes #66 

# Type of Change:
- Code
- Documentation
- New feature (a non-breaking change which adds functionality pre-approved by mentors)



# How Has This Been Tested?
![renewed_claim_command](https://user-images.githubusercontent.com/24635701/41344799-9e4cc70c-6f1f-11e8-9c61-b8e61a7d2aa1.png)
![issue_claimed_slack](https://user-images.githubusercontent.com/24635701/41344857-c1292946-6f1f-11e8-80b4-46db6326f9b1.png)


# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 
- [ ] My changes generate no new warnings 
