### PR TITLE
Added feature to check if PRs are sent to unapproved issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Hence came the idea of Sysbot, which is a Slack-bot integrated with Github to st
 
 This project is currently hosted here - sombuddha2016.pythonanywhere.com and will be shifted to paid servers soon.  
 
-####Technological Stack
+#### Technological Stack
 
 This project is made with Python and using the Flask framework.
 Some of the other technologies used include Slack Event API, web-hooks and Github API, NLTK.
 
-#####Reading Resources :-
+##### Reading Resources :-
 The following are some links to read about the technologies used.
 The contributors can get used to these before contributing.
 
@@ -35,15 +35,16 @@ The contributors can get used to these before contributing.
 Functionalities
 -----
 
-####On Github:
+#### On Github:
 1. Each newly opened issue is labelled to be Not Approved by the bot.
 2. Any member of the organization can claim issues by using leaving a comment of '@sys-bot claim' on the issue.
 3. Similarly, maintainers and collaborators can assign an issue to a member by the comment '@sys-bot assign <assignee_github_username>'
 4. Any issue can be approved by maintainers and collaborators via a comment '@sys-bot approve' or via normal comments which have variants of the word approval and issue(E.g - I am approving this issue, Approve this issue, etc). Also, a check has been kept so that the author of an issue cannot approve it.
 5. A check has been kept for multiple claims( same issue can't be claimed by or assigned to multiple members) on the same issue and also any unapproved issue cannot be claimed or assigned.
-6. Any new PR that's opened get's labelled as 'Under Review'.  
+6. Any new PR that's opened get's labelled as 'Under Review'.
+7. If a PR is sent to un-approved issue, it will get closed.  
 
-####On Slack:
+#### On Slack:
 1. Any newcomer who joins Systers slack workspace gets a DM from the bot with a welcome message, providing help on how to start and how to use the bot.
 2. A slash command /sysbot_invite can be used to get invited to the newcomers team and hence become a member of the org. However it checks if the
 newcomer member level is completed as mentioned [here](http://systers.io/member-levels)
@@ -59,7 +60,7 @@ E.g. of usage - /sysbot_claim sysbot 23.
 
 Function Descriptions
 ---------
-####Slack Functions:
+#### Slack Functions:
 
 1. `dm_new_users():` This sends a direct message to any user.
 2. `is_maintainer_comment():` Checks if a certain commenter is a member of the Slack maintainers team.
@@ -72,7 +73,7 @@ Function Descriptions
 9. `get_detailed_profile():` Gets the detailed profile of a user( this includes custom fields like date of birth, and Github profile).
 10. `get_github_username_profile():` Extracts the github username from github field value.
 
-####Github Functions:
+#### Github Functions:
 1. `label_opened_issue():` Handles the labelling(not approved) of new issues.
 2. `send_github_invite():` Sends invite to Systers newcomer team.
 3. `issue_comment_approve_github():` Approves issues via approve comments on Github and via Slack.
@@ -95,9 +96,9 @@ First fork the project and clone the project using command :
 git clone https://github.com/<your username>/sysbot.git
 ```
 
-####Installing Pip
+#### Installing Pip
 
-#####On Windows
+##### On Windows
 1. After installing Python, first download [get-pip.py](https://bootstrap.pypa.io/get-pip.py) to a directory.
 2. Open cmd, and navigate to the folder where get-py was downloaded.
 3. Then run `python get-pip.py`.
@@ -105,7 +106,7 @@ git clone https://github.com/<your username>/sysbot.git
 Type `pip freeze` from this location to launch the Python interpreter.  
 [NOTE: `pip freeze` displays the version number of all modules installed in your Python non-standard library; On a fresh install, `pip freeze` probably won't have much info to show but we're more interested in any errors that might pop up here than the actual content]
 
-#####On Linux
+##### On Linux
 1. Update your System Software: Run the following command to update the package list and upgrade all of your system software to the latest version available:-  
 
 ```
@@ -123,7 +124,7 @@ sudo apt-get install python-pip
 pip -V
 ```
 
-####Installing virtualenv
+#### Installing virtualenv
 
 ##### Both Windows and Linux
 

--- a/github_functions.py
+++ b/github_functions.py
@@ -1,6 +1,6 @@
 import requests
 from flask import request, json
-from request_urls import (add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url, get_issue_url, open_issue_url, get_labels, remove_assignee_url)
+from request_urls import (add_label_url, send_team_invite, assign_issue_url, check_assignee_url, github_comment_url, get_issue_url, open_issue_url, get_labels, remove_assignee_url, close_pull_request_url)
 from auth_credentials import USERNAME,PASSWORD, newcomers_team_id
 from messages import MESSAGE
 
@@ -179,3 +179,13 @@ def unassign_issue(repo_owner, repo_name, issue_number, assignee):
     data = '{"assignees": ["%s"]}' % assignee
     response = session.delete(request_url, data=data, headers=headers)
     return response.status_code
+
+
+def close_pr(repo_owner, repo_name, pr_number):
+    session = requests.Session()
+    session.auth = (USERNAME, PASSWORD)
+    request_url = close_pull_request_url % (repo_owner, repo_name, pr_number)
+    headers = {'Accept': 'application/vnd.github.symmetra-preview+json', 'Content-Type': 'application/json'}
+    request_body = '{"state": "closed"}'
+    #Update PR status to closed
+    session.patch(request_url, data=request_body, headers=headers)

--- a/messages.py
+++ b/messages.py
@@ -49,5 +49,6 @@ MESSAGE = {
         '4. A slash command */sysbot_claim <repo_name> <issue_number> <assignee_github_username>* or */sysbot_claim <repo_name> <issue_number>* '+\
         ' ( the latter option will work if your github URL is provided on Slack) can be used to claim any issue from Github directly via Slack.\n',
     'no_permission': 'You do not have permissions for this action.',
-    'not_approved': 'This issue has not been approved yet. Please try a different issue.'
+    'not_approved': 'This issue has not been approved yet. Please try a different issue.',
+    'pr_to_unapproved_issue': 'Please send PRs only to approved issues.'
 }


### PR DESCRIPTION
# Description
Checks the issue to which a PR is sent, and closes the PR if it is sent to an unapproved issue with a suitable comment for the same.

Fixes #72 

# Type of Change:

- Code
- Documentation
- New feature (non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
The issues( one approved and one unapproved)
![issues](https://user-images.githubusercontent.com/24635701/41731394-f2e0a9f0-759b-11e8-8805-c4570b0c096d.png)

PR sent to approved issue:
![prs_to_approved_issue](https://user-images.githubusercontent.com/24635701/41719810-c7d41bce-757e-11e8-8ea9-498ba5b1f12f.png)

PR sent to unapproved issue:
![prs_to_approved_issues](https://user-images.githubusercontent.com/24635701/41719811-c90862d4-757e-11e8-83ab-9c95ada786b6.png)


# Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings 
