### PR TITLE
Added feature to check for issue template mismatch

### DIFF
--- a/main_server.py
+++ b/main_server.py
@@ -1,6 +1,6 @@
 from flask import Flask, jsonify
 from flask import request, json, Response
-from github_functions import label_opened_issue, issue_comment_approve_github, github_pull_request_label, issue_assign, github_comment, issue_claim_github, check_multiple_issue_claim, check_approved_tag, unassign_issue, close_pr
+from github_functions import label_opened_issue, issue_comment_approve_github, github_pull_request_label, issue_assign, github_comment, issue_claim_github, check_multiple_issue_claim, check_approved_tag, unassign_issue, close_pr, check_issue_template
 from stemming.porter2 import stem
 from nltk.tokenize import word_tokenize
 from auth_credentials import announcement_channel_id, BOT_ACCESS_TOKEN
@@ -24,7 +24,14 @@ def github_hook_receiver_function():
         if action!=None:
             if action == 'opened' and data.get('pull_request', '') == '':
                 #If it's an issue opened event and not PR opened event
-                response = label_opened_issue(data)
+                issue_number = data.get('issue', {}).get('number', '')
+                repo_name = data.get('repository', {}).get('name', '')
+                repo_owner = data.get('repository', {}).get('owner', {}).get('login', '')
+                issue_body = data.get('issue', {}).get('body', '')
+                #Label newly opened issue
+                label_opened_issue(data)
+                #Check if opened issue follows issue template
+                check_issue_template(repo_owner, repo_name, issue_number, issue_body)
             elif action == 'created' and data.get('comment', '') != '':
                 #If it's a issue comment event
                 issue_number = data.get('issue', {}).get('number', '')

--- a/messages.py
+++ b/messages.py
@@ -50,5 +50,6 @@ MESSAGE = {
         ' ( the latter option will work if your github URL is provided on Slack) can be used to claim any issue from Github directly via Slack.\n',
     'no_permission': 'You do not have permissions for this action.',
     'not_approved': 'This issue has not been approved yet. Please try a different issue.',
-    'pr_to_unapproved_issue': 'Please send PRs only to approved issues.'
+    'pr_to_unapproved_issue': 'Please send PRs only to approved issues.',
+    'template_mismatch': 'Please make sure that your issue follows the provided template.'
 }


### PR DESCRIPTION
# Description
Added a check on newly opened issues so that issues not following provided templates get labelled 'Template Mismatch'.

Fixes #76 

# Type of Change:
- Code
- This change requires a documentation update
- New feature (a non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
When issue is according to template:
![template_match](https://user-images.githubusercontent.com/24635701/41850070-e6296f5a-78a0-11e8-90f6-190c88db9905.png)

When issue template isn't followed:
![issue_template_mismatch_1](https://user-images.githubusercontent.com/24635701/41850086-f666ef6e-78a0-11e8-87d4-5d6a74596e69.png)
![template_mismatch_2](https://user-images.githubusercontent.com/24635701/41850092-f965f55c-78a0-11e8-9188-611a75b4cd13.png)


# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings 
