### PR TITLE
feat: Feature to add multiple labels using single command with comma seperated label names

### DIFF
--- a/code/github_functions.py
+++ b/code/github_functions.py
@@ -312,3 +312,25 @@ def check_pr_template(pr_body, repo_owner, repo_name, pr_number):
     github_comment(MESSAGE.get('pr_template_not_followed'), repo_owner, repo_name, pr_number)
     close_pr(repo_owner, repo_name, pr_number)
     return False
+
+
+def label_list_issue(repo_owner, repo_name, issue_number, comment, commenter):
+    tokens = comment.split(",")
+    labelled = 0
+    for label_name in tokens:
+        if tokens.index(label_name) == 0:
+            label_name = label_name.split("@sys-bot label")[1].strip()
+        session = requests.Session()
+        session.auth = (USERNAME, PASSWORD)
+        if label_name.strip() != "":
+            label_request_body = '["%s"]' % label_name.strip()
+            request_url = add_label_url % (repo_owner, repo_name, issue_number)
+            response = session.post(request_url, data=label_request_body, headers=headers)
+            if response.status_code == 200:
+                labelled = labelled + 1
+    if labelled == len(tokens):
+        return {"message": "All labels added to issue", "status": 200}
+    elif labelled == 0:
+        return {"message": "Some error occurred", "status": 400}
+    else:
+        return {"message": "Some labels added to issue", "status": 204}

--- a/tests/test_github_functions.py
+++ b/tests/test_github_functions.py
@@ -5,7 +5,8 @@ from code.github_functions import (check_approved_tag, label_opened_issue, send_
                                    issue_claim_github, check_multiple_issue_claim,
                                    get_issue_author, unassign_issue, check_issue_template,
                                    close_pr, are_issue_essential_components_present,
-                                   list_open_prs_from_repo, open_issue_github, check_pr_template)
+                                   list_open_prs_from_repo, open_issue_github, check_pr_template,
+                                   label_list_issue)
 from code.messages import MESSAGE
 from setup_data import (correct_issue_data, wrong_issue_data, missing_params_issue_data,
                         pr_template_with_fixes_number, pr_template_with_fixes_text,
@@ -141,3 +142,9 @@ class TestGithubFunctions(unittest.TestCase):
         response_wrong_template = check_pr_template("Test test",
                                                     'systers', 'sysbot-testing', '12')
         self.assertEqual(response_wrong_template, False)
+
+    def test_label_list_issue(self):
+        response_all_labelled = label_list_issue('systers', 'sysbot-test', 140, "@sys-bot label test-label, bug", "sammy1997")
+        self.assertEqual(response_all_labelled, {"message": "All labels added to issue", "status": 200})
+        response_error = label_list_issue('systers', 'sysbot-testing', 140, "@sys-bot label test-label, bug", "sammy1997")
+        self.assertEqual(response_error, {"message": "Some error occurred", "status": 400})

--- a/tests/test_main_server.py
+++ b/tests/test_main_server.py
@@ -133,6 +133,15 @@ class TestMainServer(unittest.TestCase):
             response_unassign_wrong_format = self.client.post('/web_hook', data=json.dumps(event_data_comment),
                                                               content_type='application/json')
             self.assertEqual(response_unassign_wrong_format.data, '{\n  "message": "Wrong command format"\n}\n')
+            event_data_comment['comment']['body'] = "@sys-bot label test-label, approved, bug"
+            event_data_comment['issue']['number'] = "140"
+            response_label_correct_format = self.client.post('/web_hook', data=json.dumps(event_data_comment),
+                                                             content_type='application/json')
+            self.assertEqual(response_label_correct_format.data, '{\n  "message": "All labels added to issue"\n}\n')
+            event_data_comment['comment']['body'] = "@sys-bot label"
+            response_label_wrong_format = self.client.post('/web_hook', data=json.dumps(event_data_comment),
+                                                             content_type='application/json')
+            self.assertEqual(response_label_wrong_format.data, '{\n  "message": "Wrong command format"\n}\n')
             response_pr_to_unapproved_issue = self.client.post('/web_hook', data=json.dumps(event_data_pr_opened),
                                                                content_type='application/json')
             self.assertEqual(response_pr_to_unapproved_issue.data, '{\n  "message": "PR sent to unapproved issue"\n}\n')


### PR DESCRIPTION
# Description
Added command to add multiple labels to issues at once. 

Fixes #129 

# Type of Change:
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
![label_test](https://user-images.githubusercontent.com/24635701/43584800-0e93b2a4-9681-11e8-9901-1fabce1c2f69.png)



# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
