### PR TITLE
Approve command versatile

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
-# Description
+### Description
 Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change.
 
 Fixes # [ISSUE]
 
-# Type of Change:
+### Type of Change:
 **Delete irrelevant options.**
 
 - Code
@@ -19,11 +19,11 @@ Fixes # [ISSUE]
 
 
 
-# How Has This Been Tested?
+### How Has This Been Tested?
 Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.
 
 
-# Checklist:
+### Checklist:
 **Delete irrelevant options.**
 
 - [ ] My PR follows the style guidelines of this project

--- a/code/github_functions.py
+++ b/code/github_functions.py
@@ -285,8 +285,8 @@ def check_pr_template(pr_body, repo_owner, repo_name, pr_number):
     # Remove blank strings
     tokens = [s.strip() for s in tokens if s != '']
     # Necessary components in the PR template
-    necessary_elements_set = {'# Description', '# Type of Change:', '# How Has This Been Tested?',
-                              '# Checklist:'}
+    necessary_elements_set = {'### Description', '### Type of Change:', '### How Has This Been Tested?',
+                              '### Checklist:'}
     # Check if issue linking statement is present
     if 'Fixes #' not in pr_body:
         github_comment(MESSAGE.get('pr_not_linked_to_issue'), repo_owner, repo_name, pr_number)
@@ -314,7 +314,7 @@ def check_pr_template(pr_body, repo_owner, repo_name, pr_number):
     return False
 
 
-def label_list_issue(repo_owner, repo_name, issue_number, comment, commenter):
+def label_list_issue(repo_owner, repo_name, issue_number, comment):
     tokens = comment.split(",")
     labelled = 0
     for label_name in tokens:

--- a/code/main_server.py
+++ b/code/main_server.py
@@ -81,7 +81,8 @@ def github_hook_receiver_function():
                     return jsonify({'message': "Coveralls comment"})
 
                 # If comment is for approving issue
-                if comment_body.lower().strip().startswith('@sys-bot approve'):
+                if comment_body.lower().strip().startswith('@sys-bot approve') or \
+                        is_variant_of_approve(comment_body.lower()):
                     issue_comment_approve_github(issue_number, repo_name, repo_owner, commenter, False)
                     return jsonify({"message": "Approve command"})
 
@@ -148,7 +149,7 @@ def github_hook_receiver_function():
                     elif len(tokens) > 3 and (author_association != 'COLLABORATOR' or author_association != 'OWNER'):
                         github_comment(MESSAGE.get('no_permission', ''), repo_owner, repo_name, issue_number)
                     else:
-                        response = label_list_issue(repo_owner, repo_name, issue_number, comment_body, commenter)
+                        response = label_list_issue(repo_owner, repo_name, issue_number, comment_body)
                         return jsonify({"message": response.get("message")})
             elif (action == 'opened' or action == 'reopened') and data.get('pull_request', '') != '':
                 # If a new PR has been sent
@@ -290,6 +291,13 @@ def lemmatize_sent(sentence):
     # and appending to stemmed tokens to lists and overheads of string conversion.
     lemmatized_sentence = ' '.join(WordNetLemmatizer().lemmatize(token) for token in word_tokenize(sentence))
     return lemmatized_sentence
+
+
+def is_variant_of_approve(sentence):
+    stemmed_sentence_tokens = get_stems(sentence).split()
+    # All variants of approve like approve, approved, approving and approval have the same stem approv
+    return ('approv' in stemmed_sentence_tokens and 'no' not in stemmed_sentence_tokens and
+            'not' not in stemmed_sentence_tokens)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/code/main_server.py
+++ b/code/main_server.py
@@ -11,10 +11,10 @@ from auth_credentials import announcement_channel_id, BOT_UID
 from slack_functions import (dm_new_users, check_newcomer_requirements,
                              approve_issue_label_slack, assign_issue_slack, claim_issue_slack,
                              open_issue_slack, send_message_ephemeral, send_message_to_channels,
-                             slack_team_name_reply, handle_message_answering, view_issue_slack)
+                             slack_team_name_reply, handle_message_answering, view_issue_slack, label_issue_slack)
 from nltk.stem import WordNetLemmatizer
 from messages import MESSAGE
-from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.scheduler import Scheduler
 from dictionaries import repo_vs_channel_id_dict, CHANNEL_LIST
 
 # The list of channels on which the bot will respond to queries
@@ -34,8 +34,8 @@ def collect_unreviewed_prs():  # pragma: no cover
             send_message_to_channels(value, message)
 
 
-schedule = BackgroundScheduler(daemon=True)
-schedule.add_job(collect_unreviewed_prs, 'interval', days=7)
+schedule = Scheduler(daemon=True)
+schedule.add_cron_job(collect_unreviewed_prs, day_of_week='sun')
 schedule.start()
 
 
@@ -265,6 +265,14 @@ def view_issue_command():
     if request.headers['Content-Type'] == 'application/x-www-form-urlencoded':
         event_data = request.form
         view_issue_slack(event_data)
+        return Response(status=200)
+
+
+@app.route('/label', methods=['POST'])
+def label_issue():
+    if request.headers['Content-Type'] == 'application/x-www-form-urlencoded':
+        event_data = request.form
+        label_issue_slack(event_data)
         return Response(status=200)
 
 

--- a/code/messages.py
+++ b/code/messages.py
@@ -89,8 +89,11 @@ MESSAGE = {
                     ' sent to respective Slack channels.\n'
                     '9. On the *intro, questions and newcomers* channels, the bot responds with list of projects based on'
                     ' the tech stack mentioned in the comments.\n'
-                    '10. On the *intro and newcomers* channel, the bot responds to questions on *getting started and about'
-                    ' Systers, AnitaB, GSoC and other programs*, and replies with more information on these topics.',
+                    '10. On the *intro and newcomers* channel, the bot responds to questions on *getting started and '
+                    'about Systers, AnitaB, GSoC and other programs*, and replies with more information on these topics.'
+                    '11. A slash command- /sysbot_label_issue <repo-name> <issue-number> [list of labels] to label an '
+                    'issue directly from Slack. Access only to members of maintainers team. '
+                    'Eg- /sysbot_label_issue sysbot-test 180 [bug, enhancement]',
     'no_permission': 'You do not have permissions for this action.',
     'not_approved': 'This issue has not been approved yet. Please try a different issue.',
     'pr_to_unapproved_issue': 'Please send PRs only to approved issues.',

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,8 @@ with list of projects based on the tech stack mentioned in the comments.
 13. On the intro and newcomers channel, the bot responds to questions 
 on getting started and about Systers, AnitaB, GSoC and other programs,
 and replies with more information on these topics.
+14. A slash command- /sysbot_label_issue <repo-name> <issue-number> [list of labels] to label an issue directly from Slack.
+Access only to members of maintainers team. Eg- /sysbot_label_issue sysbot-test 180 [bug, enhancement]
 
 More explanations on NLP part can be found [here](nlp_explainations.md)
 

--- a/tests/setup_data.py
+++ b/tests/setup_data.py
@@ -264,22 +264,22 @@ data_message_reply = {
 query_getting_started = "Can someone guide me on how to start contributing?"
 query_gender_participation = "Are female participants preferred over male at Systers?"
 
-pr_template_with_fixes_number = "## Description\r\n" \
+pr_template_with_fixes_number = "### Description\r\n" \
                                 "%s\r\n Fixes #123\r\n # Type of Change:\r\n" \
-                                "%s \r\n\r\n# How Has This Been Tested?" \
-                                "%s \r\n# Checklist:\r\n " \
+                                "%s \r\n\r\n### How Has This Been Tested?" \
+                                "%s \r\n### Checklist:\r\n " \
                                 "- [ ] %s.\r\n"
 
-pr_template_with_fixes_text = "## Description\r\n" \
-                              "%s\r\n Fixes #abc\r\n # Type of Change:\r\n" \
-                              "%s \r\n\r\n# How Has This Been Tested?" \
-                              "%s \r\n# Checklist:\r\n " \
+pr_template_with_fixes_text = "### Description\r\n" \
+                              "%s\r\n Fixes #abc\r\n ### Type of Change:\r\n" \
+                              "%s \r\n\r\n### How Has This Been Tested?" \
+                              "%s \r\n### Checklist:\r\n " \
                               "- [ ] %s.\r\n"
 
-pr_template_without_fixes = "## Description\r\n" \
-                            "%s\r\n # Type of Change:\r\n" \
-                            "%s \r\n\r\n# How Has This Been Tested?" \
-                            "%s \r\n# Checklist:\r\n " \
+pr_template_without_fixes = "### Description\r\n" \
+                            "%s\r\n ### Type of Change:\r\n" \
+                            "%s \r\n\r\n### How Has This Been Tested?" \
+                            "%s \r\n### Checklist:\r\n " \
                             "- [ ] %s.\r\n"
 
 event_data_issue_opened = {
@@ -320,12 +320,12 @@ event_data_comment = {
 event_data_pr_opened = {
     "action": "opened",
     "pull_request": {
-        "body": "## Description\r\n"
+        "body": "### Description\r\n"
                 "Some Description\r\n Fixes #151\r\n "
-                "# Type of Change:\r\n"
+                "### Type of Change:\r\n"
                 "Explain the changes \r\n"
-                "# How Has This Been Tested?\r\n"
-                "Tested \r\n# Checklist:\r\n"
+                "### How Has This Been Tested?\r\n"
+                "Tested \r\n### Checklist:\r\n"
                 "- [ ] Checklist Point.\r\n",
         "number": "13",
     },
@@ -416,4 +416,18 @@ pr_review_error_event_data = {
         "state": "changes_requested",
         "author_association": "COLLABORATOR"
     }
+}
+
+slash_command_label_issue_data = {
+    "channel_id": "CAP9GA5MJ",
+    "channel_name": "sysbot-testing",
+    "command": "/sysbot_label_issue",
+    "response_url": "https://hooks.slack.com/commands/T08C86GE8/411060288517/Aj1nuE1p8x4bEbBRIfQ44hRT",
+    "team_domain": "systers-opensource",
+    "team_id": "T08C86GE8",
+    "text": "sysbot-test 181 [bug, enhancement]",
+    "token": "9WMeKrR9ig79X8PY1jGnzkn5",
+    "trigger_id": "411060288533.8416220484.49610058e1a1a50a5f8231694862f9b5",
+    "user_id": "U7KMRCS5Q",
+    "user_name": "f2016165"
 }

--- a/tests/test_main_server.py
+++ b/tests/test_main_server.py
@@ -5,7 +5,8 @@ from setup_data import (slash_command_help_data, sentence, slash_command_open_is
                         slash_command_claim_data, slash_command_assign_issue_data,
                         slash_command_approve_issue_data, data_with_challenge_token,
                         data_member_joined_channel, data_app_mention_channel, data_message_reply,
-                        event_data_issue_opened, event_data_comment, event_data_pr_opened)
+                        event_data_issue_opened, event_data_comment, event_data_pr_opened,
+                        slash_command_label_issue_data)
 
 
 class TestMainServer(unittest.TestCase):
@@ -126,6 +127,7 @@ class TestMainServer(unittest.TestCase):
                                                              content_type='application/json')
             self.assertEqual(response_unclaim_wrong_format.data, '{\n  "message": "Wrong command format"\n}\n')
             event_data_comment['comment']['body'] = "@sys-bot unassign sammy1997"
+            event_data_comment['comment']['author_association'] = 'COLLABORATOR'
             response_unassign = self.client.post('/web_hook', data=json.dumps(event_data_comment),
                                                  content_type='application/json')
             self.assertEqual(response_unassign.data, '{\n  "message": "Issue unassigned"\n}\n')
@@ -153,6 +155,12 @@ class TestMainServer(unittest.TestCase):
             response_unhandled = self.client.post('/web_hook', data=json.dumps(event_data_pr_opened),
                                                   content_type='application/json')
             self.assertEqual(response_unhandled.data, '{\n  "message": "Unknown event"\n}\n')
+
+    def test_label_issue(self):
+        with self.client:
+            response = self.client.post('/label', data=json.dumps(slash_command_label_issue_data),
+                                        content_type='application/json')
+            self.assertEqual(200, response.status_code)
 
 
 if __name__ == '__main__':

--- a/tests/test_slack_functions.py
+++ b/tests/test_slack_functions.py
@@ -3,11 +3,11 @@ from code.slack_functions import (get_github_username_profile, get_detailed_prof
                                   is_maintainer_comment, check_newcomer_requirements,
                                   luis_classifier, dm_new_users, slack_team_name_reply,
                                   answer_keyword_faqs, approve_issue_label_slack,
-                                  assign_issue_slack, claim_issue_slack, view_issue_slack)
+                                  assign_issue_slack, claim_issue_slack, view_issue_slack, label_issue_slack)
 from setup_data import (profile_with_github, profile_without_github, query_getting_started,
                         query_gender_participation, new_user_data, faq_sentence,
                         slash_command_approve_issue_data, slash_command_assign_issue_data,
-                        slash_command_claim_data, slash_command_view_issue_data)
+                        slash_command_claim_data, slash_command_view_issue_data, slash_command_label_issue_data)
 
 
 class TestSlackFunctions(unittest.TestCase):
@@ -107,3 +107,13 @@ class TestSlackFunctions(unittest.TestCase):
         slash_command_view_issue_data['text'] = "sysbot-testing 178 sammy1997"
         response_wrong_params = view_issue_slack(slash_command_view_issue_data)
         self.assertEqual(response_wrong_params, {'message': "Error in using command"})
+
+    def test_label_issue_slack(self):
+        label_success = label_issue_slack(slash_command_label_issue_data)
+        self.assertEqual(label_success, {'message': 'Labelled issue'})
+        slash_command_label_issue_data['text'] = "sysbot-testing 181 [bug, enhancement]"
+        label_wrong_info = label_issue_slack(slash_command_label_issue_data)
+        self.assertEqual(label_wrong_info, {'message': 'Wrong info'})
+        slash_command_label_issue_data['text'] = "sysbot-testing 181"
+        label_wrong_params = label_issue_slack(slash_command_label_issue_data)
+        self.assertEqual(label_wrong_params, {'message': 'Wrong format'})


### PR DESCRIPTION
# Description
Added more versatile approval command.

Fixes #57

# Type of Change: 
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)


# How Has This Been Tested?
![versatile_approval](https://user-images.githubusercontent.com/24635701/43904360-0df029aa-9c0c-11e8-8f91-1e13a7865558.png)



# Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
