### PR TITLE
code/dictionaries: end the triple-quoted string literal

### DIFF
--- a/code/dictionaries.py
+++ b/code/dictionaries.py
@@ -1,4 +1,4 @@
-""" Channel ID's and message keys within dictionary. ""
+""" Channel ID's and message keys within dictionary. """
 
 # Channel ids for each repo
 repo_vs_channel_id_dict = {


### PR DESCRIPTION
### Description
The triple-quoted string literal was not ended which was throwing an error while starting the server using `python main_server.py`

Fixes #174 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
python `main_server.py` runs without throwing errors.

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 